### PR TITLE
fix: scriptShell option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ await libexec({
   - `packages`: A list of packages to be used (possibly fetch from the registry) **Array<String>**, defaults to `[]`
   - `path`: Location to where to read local project info (`package.json`) **String**, defaults to `.`
   - `runPath`: Location to where to execute the script **String**, defaults to `.`
-  - `shell`: Default shell to be used **String**
+  - `scriptShell`: Default shell to be used **String**
   - `yes`: Should skip download confirmation prompt when fetching missing packages from the registry? **Boolean**
   - `registry`, `cache`, and more options that are forwarded to [@npmcli/arborist](https://github.com/npm/arborist/) and [pacote](https://github.com/npm/pacote/#options) **Object**
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ const exec = async (opts) => {
     packages: _packages = [],
     path = '.',
     runPath = '.',
-    shell = undefined,
+    scriptShell = undefined,
     yes = undefined,
     ...flatOptions
   } = opts
@@ -58,7 +58,7 @@ const exec = async (opts) => {
     path,
     pathArr,
     runPath,
-    shell,
+    scriptShell,
   })
 
   // nothing to maybe install, skip the arborist dance

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -23,10 +23,10 @@ const run = async ({
   path,
   pathArr,
   runPath,
-  shell,
+  scriptShell,
 }) => {
   // turn list of args into command string
-  const script = call || args.shift() || shell
+  const script = call || args.shift() || scriptShell
   const colorize = color ? chalk : nocolor
 
   // do the fakey runScript dance
@@ -45,7 +45,7 @@ const run = async ({
     log.disableProgress()
 
   try {
-    if (script === shell) {
+    if (script === scriptShell) {
       const isTTY = !noTTY()
 
       if (isTTY) {

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ const baseOpts = {
   path: '',
   registry,
   runPath: '',
-  shell: process.platform === 'win32'
+  scriptShell: process.platform === 'win32'
     ? process.env.ComSpec || 'cmd'
     : process.env.SHELL || 'sh',
   yes: true,


### PR DESCRIPTION
`shell` is not a valid option of `@npmcli/run-script` so that using that as an option was just not functional at all, this fixes the surface API and docs in order to actually allow consumers of the module to specify a custom shell value.