### PR TITLE
feat: add walk up dir lookup to satisfy local bins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ await libexec({
   - `call`: An alternative command to run when using `packages` option **String**, defaults to empty string.
   - `cache`: The path location to where the npm cache folder is placed **String**
   - `color`: Output should use color? **Boolean**, defaults to `false`
-  - `localBin`: Location to the `node_modules/.bin` folder of the local project **String**, defaults to empty string.
+  - `localBin`: Location to the `node_modules/.bin` folder of the local project **String** to start scanning for bin files, defaults to `./node_modules/.bin`. **libexec** will walk up the directory structure looking for `node_modules/.bin` folders in parent folders that might satisfy the current `arg` and will use that bin if found.
   - `locationMsg`: Overrides "at location" message when entering interactive mode **String**
   - `log`: Sets an optional logger **Object**, defaults to `proc-log` module usage.
   - `globalBin`: Location to the global space bin folder, same as: `$(npm bin -g)` **String**, defaults to empty string.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ await libexec({
   - `call`: An alternative command to run when using `packages` option **String**, defaults to empty string.
   - `cache`: The path location to where the npm cache folder is placed **String**
   - `color`: Output should use color? **Boolean**, defaults to `false`
-  - `localBin`: Location to the `node_modules/.bin` folder of the local project **String** to start scanning for bin files, defaults to `./node_modules/.bin`. **libexec** will walk up the directory structure looking for `node_modules/.bin` folders in parent folders that might satisfy the current `arg` and will use that bin if found.
+  - `localBin`: Location to the `node_modules/.bin` folder of the local project to start scanning for bin files **String**, defaults to `./node_modules/.bin`. **libexec** will walk up the directory structure looking for `node_modules/.bin` folders in parent folders that might satisfy the current `arg` and will use that bin if found.
   - `locationMsg`: Overrides "at location" message when entering interactive mode **String**
   - `log`: Sets an optional logger **Object**, defaults to `proc-log` module usage.
   - `globalBin`: Location to the global space bin folder, same as: `$(npm bin -g)` **String**, defaults to empty string.

--- a/lib/file-exists.js
+++ b/lib/file-exists.js
@@ -1,0 +1,26 @@
+const { dirname, resolve } = require('path')
+const { promisify } = require('util')
+const stat = promisify(require('fs').stat)
+
+const fileExists = (file) => stat(file)
+  .then((stat) => stat.isFile())
+  .catch(() => false)
+
+const localFileExists = async (dir, binName) => {
+  const binDir = resolve(dir, 'node_modules', '.bin')
+
+  // return localBin if existing file is found
+  if (await fileExists(resolve(binDir, binName)))
+    return binDir
+
+  // no more dirs left to walk up, file just does not exist
+  if (dir === dirname(dir))
+    return false
+
+  return localFileExists(dirname(dir), binName)
+}
+
+module.exports = {
+  fileExists,
+  localFileExists,
+}

--- a/lib/file-exists.js
+++ b/lib/file-exists.js
@@ -1,23 +1,26 @@
-const { dirname, resolve } = require('path')
+const { resolve } = require('path')
 const { promisify } = require('util')
 const stat = promisify(require('fs').stat)
+const walkUp = require('walk-up-path')
 
 const fileExists = (file) => stat(file)
   .then((stat) => stat.isFile())
   .catch(() => false)
 
-const localFileExists = async (dir, binName) => {
-  const binDir = resolve(dir, 'node_modules', '.bin')
+const localFileExists = async (dir, binName, root = '/') => {
+  root = resolve(root).toLowerCase()
 
-  // return localBin if existing file is found
-  if (await fileExists(resolve(binDir, binName)))
-    return binDir
+  for (const path of walkUp(resolve(dir))) {
+    const binDir = resolve(path, 'node_modules', '.bin')
 
-  // no more dirs left to walk up, file just does not exist
-  if (dir === dirname(dir))
-    return false
+    if (await fileExists(resolve(binDir, binName)))
+      return binDir
 
-  return localFileExists(dirname(dir), binName)
+    if (path.toLowerCase() === root)
+      return false
+  }
+
+  return false
 }
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
-const { delimiter, resolve } = require('path')
+const { delimiter, dirname, resolve } = require('path')
 const { promisify } = require('util')
 const read = promisify(require('read'))
-const stat = promisify(require('fs').stat)
 
 const Arborist = require('@npmcli/arborist')
 const ciDetect = require('@npmcli/ci-detect')
@@ -12,14 +11,11 @@ const pacote = require('pacote')
 const readPackageJson = require('read-package-json-fast')
 
 const cacheInstallDir = require('./cache-install-dir.js')
+const { fileExists, localFileExists } = require('./file-exists.js')
 const getBinFromManifest = require('./get-bin-from-manifest.js')
 const manifestMissing = require('./manifest-missing.js')
 const noTTY = require('./no-tty.js')
 const runScript = require('./run-script.js')
-
-const fileExists = (file) => stat(file)
-  .then((stat) => stat.isFile())
-  .catch(() => false)
 
 /* istanbul ignore next */
 const PATH = (
@@ -31,7 +27,7 @@ const exec = async (opts) => {
     args = [],
     call = '',
     color = false,
-    localBin = '',
+    localBin = resolve('./node_modules/.bin'),
     locationMsg = undefined,
     globalBin = '',
     output,
@@ -72,8 +68,10 @@ const exec = async (opts) => {
   // the behavior of treating the single argument as a package name
   if (needPackageCommandSwap) {
     let binExists = false
-    if (await fileExists(`${localBin}/${args[0]}`)) {
-      pathArr.unshift(localBin)
+    const dir = dirname(dirname(localBin))
+    const localBinPath = await localFileExists(dir, args[0])
+    if (localBinPath) {
+      pathArr.unshift(localBinPath)
       binExists = true
     } else if (await fileExists(`${globalBin}/${args[0]}`)) {
       pathArr.unshift(globalBin)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "pacote": "^11.3.1",
         "proc-log": "^1.0.0",
         "read": "^1.0.7",
-        "read-package-json-fast": "^2.0.2"
+        "read-package-json-fast": "^2.0.2",
+        "walk-up-path": "^1.0.0"
       },
       "devDependencies": {
         "bin-links": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "pacote": "^11.3.1",
     "proc-log": "^1.0.0",
     "read": "^1.0.7",
-    "read-package-json-fast": "^2.0.2"
+    "read-package-json-fast": "^2.0.2",
+    "walk-up-path": "^1.0.0"
   }
 }

--- a/test/file-exists.js
+++ b/test/file-exists.js
@@ -1,0 +1,14 @@
+const t = require('tap')
+const { localFileExists } = require('../lib/file-exists.js')
+
+t.test('missing root value', async t => {
+  const dir = t.testdir({
+    b: {
+      c: {},
+    },
+  })
+
+  // root value a is not part of the file system hierarchy
+  const fileExists = await localFileExists(dir, 'foo', 'a')
+  t.equal(fileExists, false, 'should return false on missing root')
+})


### PR DESCRIPTION
Currently `@npmcli/run-script` already supports this walk up lookup logic
that allows any nested folder to use a bin that is located inside a
`node_modules/.bin` folder higher in the directory tree.

This commit adds the same logic from:
https://github.com/npm/run-script/blob/47a4d539fb07220e7215cc0e482683b76407ef9b/lib/set-path.js#L24-L28
to libnpmexec so that users may use a binary from a dependency of a
nested workspace in the context of that workspace's folder.


## References
Fixes: https://github.com/npm/cli/issues/2826

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
