### PR TITLE
Specify 'en' locale to String.localeCompare

### DIFF
--- a/lib/cache-install-dir.js
+++ b/lib/cache-install-dir.js
@@ -12,7 +12,7 @@ const cacheInstallDir = ({ cache, packages }) => {
 
 const getHash = (packages) =>
   crypto.createHash('sha512')
-    .update(packages.sort((a, b) => a.localeCompare(b)).join('\n'))
+    .update(packages.sort((a, b) => a.localeCompare(b, 'en')).join('\n'))
     .digest('hex')
     .slice(0, 16)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,7 +143,7 @@ const exec = async (opts) => {
       },
     }))
       .map(mani => mani._from)
-      .sort((a, b) => a.localeCompare(b))
+      .sort((a, b) => a.localeCompare(b, 'en'))
 
     // no need to install if already present
     if (add.length) {


### PR DESCRIPTION
No test added, since there's nothing in this module that particularly
depends on string sorting, but it's a best practice all the same.

Re: https://github.com/npm/cli/issues/2829

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
