### PR TITLE
add default scriptShell value

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ await libexec({
   - `packages`: A list of packages to be used (possibly fetch from the registry) **Array<String>**, defaults to `[]`
   - `path`: Location to where to read local project info (`package.json`) **String**, defaults to `.`
   - `runPath`: Location to where to execute the script **String**, defaults to `.`
-  - `scriptShell`: Default shell to be used **String**
+  - `scriptShell`: Default shell to be used **String**, defaults to `sh` on POSIX systems, `process.env.ComSpec` OR `cmd` on Windows
   - `yes`: Should skip download confirmation prompt when fetching missing packages from the registry? **Boolean**
   - `registry`, `cache`, and more options that are forwarded to [@npmcli/arborist](https://github.com/npm/arborist/) and [pacote](https://github.com/npm/pacote/#options) **Object**
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ const getBinFromManifest = require('./get-bin-from-manifest.js')
 const manifestMissing = require('./manifest-missing.js')
 const noTTY = require('./no-tty.js')
 const runScript = require('./run-script.js')
+const isWindows = require('./is-windows.js')
 
 /* istanbul ignore next */
 const PATH = (
@@ -34,7 +35,7 @@ const exec = async (opts) => {
     packages: _packages = [],
     path = '.',
     runPath = '.',
-    scriptShell = undefined,
+    scriptShell = isWindows ? process.env.ComSpec || 'cmd' : 'sh',
     yes = undefined,
     ...flatOptions
   } = opts

--- a/lib/is-windows.js
+++ b/lib/is-windows.js
@@ -1,0 +1,1 @@
+module.exports = process.platform === 'win32'


### PR DESCRIPTION
- Fixes `npm exec` interactive shell
- Relates to: https://github.com/npm/cli/issues/3327
