### PR TITLE
fix: fix npx failed to install package and exec, when cache dir is a symlink

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
+const fs = require('fs')
 const { delimiter, dirname, resolve } = require('path')
 const { promisify } = require('util')
 const read = promisify(require('read'))
+const realpath = promisify(fs.realpath)
 
 const Arborist = require('@npmcli/arborist')
 const ciDetect = require('@npmcli/ci-detect')
@@ -125,8 +127,9 @@ const exec = async (opts) => {
 
   if (needInstall) {
     const { cache } = flatOptions
-    const installDir = cacheInstallDir({ cache, packages })
-    await mkdirp(installDir)
+    const cacheDir = cacheInstallDir({ cache, packages })
+    await mkdirp(cacheDir)
+    const installDir = await realpath(cacheDir)
     const arb = new Arborist({
       ...flatOptions,
       path: installDir,


### PR DESCRIPTION
fix by make sure cacheInstallDir always be a realpath

Relates to: https://github.com/npm/cli/issues/3431